### PR TITLE
Don't overwrite when merging config

### DIFF
--- a/src/url-builder.ts
+++ b/src/url-builder.ts
@@ -6,10 +6,17 @@ const defaultOptions: UrlBuilderOptions = {
 };
 
 function mergeConfig (options1: UrlBuilderOptions, options2: UrlBuilderOptions): UrlBuilderOptions {
-    for (const optionName in options2) {
-        options1[optionName] = options2[optionName];
+    const config: UrlBuilderOptions = [];
+
+    for (const optionName in options1) {
+        config[optionName] = options1[optionName];
     }
-    return options1;
+
+    for (const optionName in options2) {
+        config[optionName] = options2[optionName];
+    }
+
+    return config;
 }
 
 class UrlBuilder {

--- a/tests/url-builder.spec.ts
+++ b/tests/url-builder.spec.ts
@@ -164,3 +164,17 @@ describe('correct parameters binding', () => {
         expect(url).toEqual('https://www.example.com/homepage?param[]=2&param[]=3')
     });
 });
+
+describe('config', () => {
+    test('multiple instances do not share config', () => {
+        routes = { 'route1': '/homepage' };
+        const urlBuilder1 = new UrlBuilder(routes, { baseURL: 'https://www.example.com' });
+        const urlBuilder2 = new UrlBuilder(routes );
+    
+        const url1 = urlBuilder1.build('route1');
+        const url2 = urlBuilder2.build('route1');
+
+        expect(url1.get()).not.toEqual(url2.get());
+        expect(url2.get()).toEqual('http://localhost/homepage');
+    });
+});


### PR DESCRIPTION
This change is effectively a breaking change, but I feel like the current implementation is unintended, i.e. if I have:

```js
const routes = { 'route1': '/homepage' };
const urlBuilder1 = new UrlBuilder(routes, { baseURL: 'https://www.example.com' });
const urlBuilder2 = new UrlBuilder(routes);
    
const url1 = urlBuilder1.build('route1');
const url2 = urlBuilder2.build('route1');
```

I would _not_ expect `url2` to have a `baseURL` of `'https://www.example.com'`, but that's currently what happens. So, this change means subsequent instances of `UrlBuilder` do not share config from previous instances.

cc @Flyrell 