### PR TITLE
Support baseURLs with paths

### DIFF
--- a/src/get-path.ts
+++ b/src/get-path.ts
@@ -1,0 +1,22 @@
+import UrlParse from "url-parse";
+
+const getPath = (path: string, baseURL?: string) => {
+    if (baseURL) {
+        const urlParse = new UrlParse(baseURL);
+        const { pathname } = urlParse;
+
+        if (pathname !== '') {
+            const { length } = pathname;
+
+            if (pathname[length - 1] === '/') {
+                return pathname.substring(0, length - 1) + path;
+            }
+
+            return pathname + path;
+        }
+    }
+
+    return path;
+};
+
+export default getPath;

--- a/src/route-builder.ts
+++ b/src/route-builder.ts
@@ -1,4 +1,5 @@
-import * as UrlParse from "url-parse";
+import UrlParse from "url-parse";
+import getPath from "./get-path";
 
 class RouteBuilder {
 
@@ -8,7 +9,7 @@ class RouteBuilder {
 
     constructor (name: string, path: string, baseURL?: string) {
         this.name = name;
-        this.url = new UrlParse(path, baseURL, () => ({}));
+        this.url = new UrlParse(getPath(path, baseURL), baseURL, () => ({}));
     }
 
     setQueryParameter (name: string, value: any) {

--- a/tests/get-path.spec.ts
+++ b/tests/get-path.spec.ts
@@ -1,0 +1,53 @@
+import getPath from "../src/get-path";
+
+describe('getPath with no baseURL', () => {
+
+    test('it returns the path when baseURL not specified', () => {
+        const expected = '/path';
+        const actual = getPath(expected);
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('it returns the path when baseURL is `null`', () => {
+        const expected = '/path';
+        const actual = getPath(expected, null);
+
+        expect(actual).toEqual(expected);
+    });
+
+});
+
+describe('getPath with baseURL', () => {
+
+    test('it returns the path when baseURL is protocol, host, port', () => {
+        const expected = '/path';
+        const actual = getPath(expected, 'https://example.com:443');
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('it returns the path when baseURL is protocol relative', () => {
+        const expected = '/path';
+        const actual = getPath(expected, '//example.com');
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('it returns the path when baseURL includes a path', () => {
+        const path = '/path'
+        const expected = '/foo/path';
+        const actual = getPath(path, 'https://example.com/foo');
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('it returns the path when baseURL includes a path with a trailing /', () => {
+        const path = '/path'
+        const expected = '/foo/path';
+        const actual = getPath(path, 'https://example.com/foo/');
+
+        expect(actual).toEqual(expected);
+    });
+
+});

--- a/tests/url-builder.spec.ts
+++ b/tests/url-builder.spec.ts
@@ -101,6 +101,38 @@ describe('correct route building without parameters', () => {
         expect(urlBuilder.build('route1').get()).toEqual('https://www.example.com/homepage');
         expect(urlBuilder.build('route1trailing').get()).toEqual('https://www.example.com/homepage/');
     });
+
+    test('from routeConfig with global baseURL that includes path', () => {
+        routes = {
+            'route1': {
+                path: '/homepage'
+            },
+            'route1trailing': {
+                path: '/homepage/'
+            }
+        };
+        const urlBuilder = new UrlBuilder(routes, {
+            baseURL: 'https://www.example.com/path'
+        });
+        expect(urlBuilder.build('route1').get()).toEqual('https://www.example.com/path/homepage');
+        expect(urlBuilder.build('route1trailing').get()).toEqual('https://www.example.com/path/homepage/');
+    });
+
+    test('from routeConfig with global baseURL that includes path with trailing /', () => {
+        routes = {
+            'route1': {
+                path: '/homepage'
+            },
+            'route1trailing': {
+                path: '/homepage/'
+            }
+        };
+        const urlBuilder = new UrlBuilder(routes, {
+            baseURL: 'https://www.example.com/path/'
+        });
+        expect(urlBuilder.build('route1').get()).toEqual('https://www.example.com/path/homepage');
+        expect(urlBuilder.build('route1trailing').get()).toEqual('https://www.example.com/path/homepage/');
+    });
 });
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "./dist",
+    "esModuleInterop": true,
     "module": "es6",
     "noImplicitAny": true,
     "outDir": "./dist",


### PR DESCRIPTION
@Flyrell change how library works to support baseURLs that include a path, e.g.

  https://example.com/v1
  https://example.com/staging

this means I can do something like this:

```js
const routes = {
  'endpoint': {
    path: '/endpoint'
  }
};

const urlBuilder = new UrlBuilder(routes, {
  baseURL: 'https://www.example.com/v1'
});

// https://www.example.com/v1/endpoint
const url = urlBuilder.build('endpoint');
```