### PR TITLE
Change name to routeName

### DIFF
--- a/src/url-builder.ts
+++ b/src/url-builder.ts
@@ -40,7 +40,7 @@ class UrlBuilder {
         }
 
         const baseURL = route.baseURL ? route.baseURL : this.options.baseURL;
-        return new RouteBuilder(name, route.path, baseURL);
+        return new RouteBuilder(routeName, route.path, baseURL);
     }
 }
 


### PR DESCRIPTION
`name` is not defined in this file and comes from `lib.dom.ts` (which is included by default if `lib` is not specified in `tsconfig.json`).

This code will probably work in browser environments, but throws an error when running in Node because `name` is not defined.

cc @Flyrell 